### PR TITLE
Can use spatie/laravel-missing-page-redirector 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This package provides a Nova Tool to manage redirects with [spatie/laravel-missi
 
 * PHP >= 7.2
 * Laravel Nova >= 2.0
-* Laravel Framework >= 5.8
+* Laravel Framework >= 5.7
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=7.2.0",
-        "spatie/laravel-missing-page-redirector": "^2.5"
+        "spatie/laravel-missing-page-redirector": "^2.4|^2.5"
     },
     "require-dev": {
       "friendsofphp/php-cs-fixer": "~2.16.1"


### PR DESCRIPTION
When website uses laravel 5.7, spatie/laravel-missing-page-redirector needs to be in 2.4